### PR TITLE
Build Docker container

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "nbgv": {
+      "version": "3.5.119",
+      "commands": [
+        "nbgv"
+      ]
+    }
+  }
+}

--- a/.dockerignore
+++ b/.dockerignore
@@ -21,5 +21,6 @@
 **/obj
 **/secrets.dev.yaml
 **/values.dev.yaml
+__*
 LICENSE
 README.md

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,6 +38,16 @@ jobs:
       - name: Install dependencies
         run: dotnet restore
 
+      - name: Install .NET tools
+        run: dotnet tool restore
+
+      - name: Set version
+        id: version
+        shell: pwsh
+        run: |
+          $packageVersion = dotnet nbgv get-version --variable NuGetPackageVersion
+          "container_version=$packageVersion" >> $env:GITHUB_ENV
+
       - name: DotNet Format
         run: dotnet format --no-restore --verify-no-changes
 
@@ -63,3 +73,30 @@ jobs:
         with:
           name: __publish
           path: __publish
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # https://github.com/docker/build-push-action
+      - name: Build and push container image
+        uses: docker/build-push-action@v2
+        with:
+          file: src/Synology.Ddns.Update.Service/Dockerfile
+          # relative path to the place where source code with Dockerfile is located
+          context: __publish/Release/AnyCPU/src/Synology.Ddns.Update.Service/net7.0
+          # build-time arguments
+          build-args: |
+            finalStage=fromlocal
+          # Note: tags has to be all lower-case
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/synologyddnsupdater:${{ env.container_version }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/synologyddnsupdater:latest
+          # build on feature branches, push only on main branch
+          push: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -43,3 +43,22 @@ jobs:
           directory: __test-results
           fail_ci_if_error: true
           verbose: true
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build container image
+        uses: docker/build-push-action@v2
+        with:
+          file: src/Synology.Ddns.Update.Service/Dockerfile
+          # relative path to the place where source code with Dockerfile is located
+          context: __publish/Release/AnyCPU/src/Synology.Ddns.Update.Service/net7.0
+          # build-time arguments
+          build-args: |
+            finalStage=fromlocal
+          # Note: tags has to be all lower-case
+          tags: |
+            synologyddnsupdater:pr
+          # Never push on PR builds
+          push: false

--- a/README.md
+++ b/README.md
@@ -44,10 +44,16 @@ When configuring your DDNS, use something like the following:
 Note: I would have preferred to use the Namecheap domain name for the "Username/Email", but the DDNS form doesn't allow
 the use of the `@` symbol in the "Hostname" field.
 
+## Hosting the application yourself
+
+You can follow the instructions [here][synology-ddns-update-service] to learn how to configure and run the service
+yourself.
+
 [brettterpstra-post]: https://brettterpstra.com/2021/08/26/custom-urls-for-your-synology-with-namecheap/ "Custom URLs for your Synology with Namecheap"
 [encodebudenet-post]: https://en.code-bude.net/2022/02/17/set-up-namecheap-com-ddns-in-synology-dsm/ "Set up Namecheap.com DDNS in Synology DSM"
 [namecheap]: https://namecheap.com "Namecheap"
 [namecheap-ddns-api]: https://www.namecheap.com/support/knowledgebase/article.aspx/29/11/how-to-dynamically-update-the-hosts-ip-with-an-http-request/ "How to dynamically update the host's IP with an HTTP request?"
 [namecheap-enable-ddns]: https://www.namecheap.com/support/knowledgebase/article.aspx/595/11/how-do-i-enable-dynamic-dns-for-a-domain/ "How do I enable Dynamic DNS for a domain?"
 [namecheap-setup-host]: https://www.namecheap.com/support/knowledgebase/article.aspx/43/11/how-do-i-set-up-a-host-for-dynamic-dns/ "How do I set up a Host for Dynamic DNS?"
+[synology-ddns-update-service]: /src/Synology.Ddns.Update.Service/README.md
 [synology-ddns]: https://kb.synology.com/en-br/DSM/help/DSM/AdminCenter/connection_ddns "Synology DDNS"

--- a/src/Synology.Ddns.Update.Service/BuildContainer.ps1
+++ b/src/Synology.Ddns.Update.Service/BuildContainer.ps1
@@ -1,0 +1,85 @@
+[CmdletBinding(DefaultParameterSetName = 'local-build')]
+param (
+    [Parameter(ParameterSetName = 'container-build')]
+    [switch] $UseContainerBuild,
+
+    [Parameter(ParameterSetName = 'local-build')]
+    [switch] $SkipPublish,
+
+    [Parameter(ParameterSetName = 'local-build')]
+    [string] $Configuration = 'Release',
+
+    [Parameter(ParameterSetName = 'local-build')]
+    [Parameter(ParameterSetName = 'container-build')]
+    [string] $RegistryName,
+
+    [Parameter(ParameterSetName = 'local-build')]
+    [Parameter(ParameterSetName = 'container-build')]
+    [string] $RepositoryName = 'synologyddnsupdater',
+
+    [Parameter(ParameterSetName = 'local-build')]
+    [Parameter(ParameterSetName = 'container-build')]
+    [string] $TagSuffix
+)
+
+$PSNativeCommandErrorActionPreference = $true
+$ErrorActionPreference = 'Stop'
+
+
+$repoRoot = & git rev-parse --show-toplevel
+$projectFolder = $PSScriptRoot
+
+Push-Location $projectFolder
+try {
+    Write-Host 'Restoring tools...' -ForegroundColor Magenta
+    dotnet tool restore
+}
+finally {
+    Pop-Location
+}
+
+$version = & dotnet nbgv get-version --variable NuGetPackageVersion
+
+Write-Host "Got version: $version" -ForegroundColor Cyan
+
+$tag = "$($RepositoryName):$version"
+
+if ($TagSuffix) {
+    $tag += $TagSuffix
+}
+
+if ($RegistryName) {
+    $tag = "$RegistryName/$tag"
+}
+
+Write-Host "Will use tag: $tag" -ForegroundColor Cyan
+
+if ($PsCmdlet.ParameterSetName -eq 'local-build') {
+
+    if (-not $SkipPublish) {
+        Write-Host "Performing a publish with $Configuration configuration..." -ForegroundColor Magenta
+
+        dotnet publish $projectFolder --configuration $Configuration
+    }
+
+    $context = Join-Path $repoRoot "__publish/$Configuration/AnyCPU/src/Synology.Ddns.Update.Service/net7.0"
+
+    if (-not (Test-Path $context)) {
+        throw "Expected publish output was not found: $context"
+    }
+
+    Write-Host 'Building the container using host built application...' -ForegroundColor Magenta
+
+    docker build -f $projectFolder/Dockerfile --build-arg finalStage=fromlocal --force-rm -t $tag $context
+}
+else {
+    $context = $repoRoot
+
+    Write-Host 'Building the container using container built application...' -ForegroundColor Magenta
+
+    docker build -f $projectFolder/Dockerfile --force-rm -t $tag $context
+}
+
+Write-Host "Built and tagged the container: $tag" -ForegroundColor Magenta
+
+Write-Host 'Done' -ForegroundColor Green

--- a/src/Synology.Ddns.Update.Service/Dockerfile
+++ b/src/Synology.Ddns.Update.Service/Dockerfile
@@ -1,25 +1,66 @@
-#See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
+﻿#See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
+ARG aspNetVersion=7.0
+ARG baseTag=${aspNetVersion}-cbl-mariner2.0-distroless
+ARG buildTag=${aspNetVersion}
+ARG appPath=./
+
+# Set to "fromlocal" to simply copy in locally built bits from appPath.
+ARG finalStage=frompublish
+
+FROM mcr.microsoft.com/dotnet/aspnet:${baseTag} AS base
+
 WORKDIR /app
-EXPOSE 80
-EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
-WORKDIR /src
+EXPOSE 8080
+EXPOSE 5443
+
+ENV \
+    # Configure web servers to bind to port 8080 and 5443 when present
+    ASPNETCORE_URLS=http://+:8080;https://+:5443 \
+    ASPNETCORE_HTTPS_PORT=5443
+
+# Condition: finalStage=frompublish
+FROM mcr.microsoft.com/dotnet/sdk:${buildTag} AS build
+
+WORKDIR /repo
+
+COPY ["Directory.Build.props", "."]
+COPY ["Directory.Packages.props", "."]
+COPY ["global.json", "."]
 COPY ["nuget.config", "."]
+COPY ["version.json", "."]
+COPY ["eng", "eng"]
+COPY ["src/.editorconfig", "src/"]
+COPY ["src/Directory.Packages.props", "src/"]
 COPY ["src/Synology.Ddns.Update.Service/Synology.Ddns.Update.Service.csproj", "src/Synology.Ddns.Update.Service/"]
 COPY ["src/Namecheap.Library/Namecheap.Library.csproj", "src/Namecheap.Library/"]
 COPY ["src/Synology.Namecheap.Adapter.Library/Synology.Namecheap.Adapter.Library.csproj", "src/Synology.Namecheap.Adapter.Library/"]
 RUN dotnet restore "src/Synology.Ddns.Update.Service/Synology.Ddns.Update.Service.csproj"
+
 COPY . .
-WORKDIR "/src/src/Synology.Ddns.Update.Service"
-RUN dotnet build "Synology.Ddns.Update.Service.csproj" -c Release -o /app/build
 
+WORKDIR "/repo/src/Synology.Ddns.Update.Service"
+
+RUN dotnet build "Synology.Ddns.Update.Service.csproj" -c Release
+
+# Condition: finalStage=frompublish
 FROM build AS publish
-RUN dotnet publish "Synology.Ddns.Update.Service.csproj" -c Release -o /app/publish /p:UseAppHost=false
 
-FROM base AS final
+RUN dotnet publish "Synology.Ddns.Update.Service.csproj" -c Release /p:UseAppHost=false
+
+# Condition: finalStage=frompublish
+FROM base AS frompublish
+
 WORKDIR /app
-COPY --from=publish /app/publish .
+
+COPY --from=publish /repo/__publish/Release/AnyCPU/src/Synology.Ddns.Update.Service/net7.0 .
+
+# Condition: finalStage=fromlocal
+FROM base AS fromlocal
+
+COPY $appPath /app
+
+FROM ${finalStage} AS final
+
 ENTRYPOINT ["dotnet", "Synology.Ddns.Update.Service.dll"]

--- a/src/Synology.Ddns.Update.Service/Options/MonitoringOptions.cs
+++ b/src/Synology.Ddns.Update.Service/Options/MonitoringOptions.cs
@@ -8,7 +8,7 @@ internal class MonitoringOptions
     public const string SectionName = nameof(MonitoringOptions);
 
     /// <summary>
-    /// Gets or sets a value indicating whether OopenTelemetry should be enabled.
+    /// Gets or sets a value indicating whether OpenTelemetry should be enabled.
     /// </summary>
     public bool OpenTelemetryEnabled { get; set; }
 

--- a/src/Synology.Ddns.Update.Service/Program.cs
+++ b/src/Synology.Ddns.Update.Service/Program.cs
@@ -60,7 +60,6 @@ internal sealed class Program
 
         app.MapControllers();
 
-
         app.Run();
     }
 }

--- a/src/Synology.Ddns.Update.Service/Properties/launchSettings.json
+++ b/src/Synology.Ddns.Update.Service/Properties/launchSettings.json
@@ -1,15 +1,18 @@
-{
+﻿{
   "$schema": "https://json.schemastore.org/launchsettings.json",
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:17971",
-      "sslPort": 44335
-    }
-  },
   "profiles": {
-    "Service | Dev | https": {
+    "Project | https | Mock": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7257;http://localhost:5064",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "NamecheapDdnsClientOptions__MockClient": "true"
+      }
+    },
+    "Project | https | Real": {
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
@@ -19,17 +22,18 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "Service | Prod | https": {
+    "Project | http | Mock": {
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "https://localhost:7257;http://localhost:5064",
+      "applicationUrl": "http://localhost:5064",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Production"
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "NamecheapDdnsClientOptions__MockClient": "true"
       }
     },
-    "Service | Dev | http": {
+    "Project | http | Real": {
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
@@ -39,20 +43,39 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "launchUrl": "swagger",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "Docker": {
+    "Docker | https | Mock": {
       "commandName": "Docker",
       "launchBrowser": true,
       "launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}/swagger",
-      "publishAllPorts": true,
+      "useSSL": true,
+      "environmentVariables": {
+        "NamecheapDdnsClientOptions__MockClient": "true"
+      }
+    },
+    "Docker | https | Real": {
+      "commandName": "Docker",
+      "launchBrowser": true,
+      "launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}/swagger",
       "useSSL": true
+    },
+    "Docker | http | Mock": {
+      "commandName": "Docker",
+      "launchBrowser": true,
+      "launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}/swagger",
+      "environmentVariables": {
+        "NamecheapDdnsClientOptions__MockClient": "true",
+        "ASPNETCORE_URLS": "http://+"
+      },
+      "useSSL": false
+    },
+    "Docker | http | Real": {
+      "commandName": "Docker",
+      "launchBrowser": true,
+      "launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}/swagger",
+      "environmentVariables": {
+        "ASPNETCORE_URLS": "http://+"
+      },
+      "useSSL": false
     }
   }
 }

--- a/src/Synology.Ddns.Update.Service/README.md
+++ b/src/Synology.Ddns.Update.Service/README.md
@@ -1,0 +1,288 @@
+# Synology DDN Updater
+
+- [Synology DDN Updater](#synology-ddn-updater)
+  - [Building the Docker container](#building-the-docker-container)
+    - [Build Docker container using PowerShell script](#build-docker-container-using-powershell-script)
+    - [Build Docker container manually](#build-docker-container-manually)
+  - [Configuring the service](#configuring-the-service)
+    - [Namecheap DDNS client options](#namecheap-ddns-client-options)
+    - [Monitoring options](#monitoring-options)
+    - [Rate limiting options](#rate-limiting-options)
+    - [Docker options](#docker-options)
+      - [Configure Docker container with https](#configure-docker-container-with-https)
+      - [Configure Docker container with http only](#configure-docker-container-with-http-only)
+  - [Running the service](#running-the-service)
+    - [Run from Visual Studio](#run-from-visual-studio)
+    - [Run in Docker](#run-in-docker)
+    - [Run in Docker using https](#run-in-docker-using-https)
+    - [Run in Docker using http](#run-in-docker-using-http)
+
+An instance of this service is already hosted at <https://synologyddnsupdater.azurewebsites.net>, but the following
+instructions will explain how to run the service yourself.
+
+## Building the Docker container
+
+Make sure you've installed the following pre-requisites:
+
+- [Docker][docker]
+  - [Docker Desktop][docker-desktop] recommended
+- [.NET 7.0 SDK][dotnet-7-sdk-download]
+
+> **Note**
+>
+> A prebuilt container image ([craigktreasure/synologyddnsupdater][docker-image]) is also available if you're
+> comfortable with that.
+
+### Build Docker container using PowerShell script
+
+The Docker container is simple to build. There's even a PowerShell script to simplify it.
+
+To build the service within a container:
+
+```powershell
+./BuildContainer.ps1 -UseContainerBuild
+```
+
+This method will use a .NET SDK container to build the service application.
+
+To build the service using the host:
+
+```powershell
+./BuildContainer.ps1
+```
+
+This method will build the service application on the host machine and then use those bits to produce the container.
+
+### Build Docker container manually
+
+To build the service within a container:
+
+```bash
+# From the root of the repository
+docker build -f ./src/Synology.Ddns.Update.Service/Dockerfile --force-rm -t synologyddnsupdater:local .
+```
+
+This method will use a .NET SDK container to build the service application.
+
+To build the service using the host:
+
+```bash
+# From the root of the repository
+dotnet publish ./src/Synology.Ddns.Update.Service -c Release
+docker build -f ./src/Synology.Ddns.Update.Service/Dockerfile --build-arg finalStage=fromlocal --force-rm -t synologyddnsupdater:local __publish/Release/AnyCPU/src/Synology.Ddns.Update.Service/net7.0
+```
+
+This method will build the service application on the host machine and then use those bits to produce the container.
+
+## Configuring the service
+
+This list is not meant to be exhaustive, but here are some options that can be specified to change the behavior of the
+service. There are many ways to [configure][aspnetcore-configuration] an ASP.NET Core application. We'll use simple
+JSON notation here, but you can always replace `.` with `__` for environment variables.
+
+### Namecheap DDNS client options
+
+The Namecheap DDNS client is used to make calls to the Namecheap service to update DDNS records. You can enable a mock
+client that never really calls Namecheap and only returns "good" responses by setting
+`NamecheapDdnsClientOptions.MockClient` to `true`. This option defaults to `false`.
+
+### Monitoring options
+
+The application is configured with [OpenTelemetry][opentelemetry] for monitoring purposes. However, this is not yet
+enabled by default in the Production environment. It is enabled when running the service in the Development environment.
+You can override the default at any time by setting the `MonitoringOptions.OpenTelemetryEnabled` option to `true` or
+`false`.
+
+| Option                                   | Production Default | Development Default |
+|------------------------------------------|--------------------|---------------------|
+| `MonitoringOptions.OpenTelemetryEnabled` | `false`            | `true`              |
+
+### Rate limiting options
+
+The application is configured with [rate limiting][aspnetcore-ratelimiting] using the Fixed Window strategy. You can
+find the default configuration in [GlobalRateLimiterOptions.cs][globalratelimiteroptions].
+
+| Option                                 | Default    |
+|----------------------------------------|------------|
+| `GlobalRateLimiterOptions.PermitLimit` | `5`        |
+| `GlobalRateLimiterOptions.QueueLimit`  | `5`        |
+| `GlobalRateLimiterOptions.Window`      | `00:00:15` |
+
+See the [docs][aspnetcore-ratelimiting] for detailed explanations of what these values represent.
+
+### Docker options
+
+The [Dockerfile][dockerfile] is configured to build the service itself in an intermediate container and to run the
+application using ports 8080 and 5443 (https) in the ASP.NET Core 7.0 Mariner 2.0 Distroless container.
+
+| Variable name           | Description                                                                                               | Container Default              |
+|-------------------------|-----------------------------------------------------------------------------------------------------------|--------------------------------|
+| `ASPNETCORE_HTTPS_PORT` | Configures the [HTTPS port][aspnetcore-https-port].                                                       | `5443`                         |
+| `ASPNETCORE_URLS`       | Configures the [server URLs][aspnetcore-server-urls] ([also helpful][aspnetcore-server-urls-andrewlock]). | `http://+:8080;https://+:5443` |
+
+The ports can easily be overridden using the `ASPNETCORE_URLS` and `ASPNETCORE_HTTPS_PORT` environment variables. Good
+reading material can be found [here][aspnetcore-docker-https] and [here][aspnetcore-server-urls-andrewlock].
+
+There is no certificate included in the container and one will be required in the default configuration. See
+[below](#configure-docker-container-with-https).
+
+#### Configure Docker container with https
+
+First, you'll need a certificate file (pfx) and the password for that certificate file.
+
+> **TIP**
+>
+> If you have a crt, ca bundle, and the private key, you can create a pfx using openssl:
+>
+> ```shell
+> openssl pkcs12 --export -out mycertificate.pfx -inkey server.key -in mycertificate.crt -certfile mycertificate.ca-bundle
+> ```
+>
+> More detailed instructions can be found elsewhere online, but I found [this page][create-pfx-openssl] helpful.
+
+Put the certificate file (pfx) into a folder on the Docker host.
+
+Configure the container with a volume mount that includes the certificate file. This is done by specifying the `-v`
+Docker parameter with the value `<host path to certificate folder>:/https`.
+
+You'll then configure the container with some key ASP.NET Core environment variables to tell the service where to find
+the certificate and what the password is for that certificate.
+
+| Variable name                                         | Description                             | Value                      |
+|-------------------------------------------------------|-----------------------------------------|----------------------------|
+| `ASPNETCORE_Kestrel__Certificates__Default__Path`     | Configures the path to the certificate. | `/https`                   |
+| `ASPNETCORE_Kestrel__Certificates__Default__Password` | Configures the certificate password.    | Your certificate password. |
+
+Example command:
+
+```shell
+docker run -d --rm \
+    -p 58080:8080 \
+    -p 55443:5443 \
+    -e ASPNETCORE_Kestrel__Certificates__Default__Password="<certificate password>" \
+    -e ASPNETCORE_Kestrel__Certificates__Default__Path=/https/<certificate file name> \
+    -v <certificate folder path>:/https/ \
+    craigktreasure/synologyddnsupdater:1.0.4
+```
+
+#### Configure Docker container with http only
+
+By setting a key ASP.NET Core environment variable, you can easily reconfigure the container to run using http only.
+
+| Variable name           | Description                                           | Value           |
+|-------------------------|-------------------------------------------------------|-----------------|
+| `ASPNETCORE_URLS`       | Configures the [server URLs][aspnetcore-server-urls]. | `http://+:8080` |
+
+Example command:
+
+```shell
+docker run -d --rm \
+    -p 58080:8080 \
+    -e ASPNETCORE_URLS=http://+:8080 \
+    craigktreasure/synologyddnsupdater:1.0.4
+```
+
+## Running the service
+
+### Run from Visual Studio
+
+After opening the solution file in Visual Studio, select the `Synology.Ddns.Update.Service` project as the startup
+project. The, from the **Run** drop down menu, select any of the available options. Profiles have the following
+attributes:
+
+| Profile name segment | Description                                                                                     |
+|----------------------|-------------------------------------------------------------------------------------------------|
+| Project              | Runs the service on the host computer.                                                          |
+| Docker               | Runs the service in a Docker container.                                                         |
+| https                | Runs the service using https using the dev certificate.                                         |
+| http                 | Runs the service using http without TSL\SSL.                                                    |
+| Mock                 | Runs the service using the mock Namecheap DDNS client. No real calls to Namecheap will be made. |
+| Real                 | Runs the service using the real Namecheap DDNS client. Real calls will be made to Namecheap.    |
+
+One thing worth mentioning is that when Visual Studio builds the Docker container, it is configured to use a traditional
+ASP.NET Core container image for the base, which is not the default.
+
+### Run in Docker
+
+The easiest way to run the container in Docker is to execute it from [Visual Studio](#run-from-visual-studio) as it
+already handles a lot of things for you. But, not everyone uses Visual Studio and might find it more educational to run
+the service manually.
+
+Make sure you've installed the following pre-requisites:
+
+- [Docker][docker]
+  - [Docker Desktop][docker-desktop] recommended
+- [.NET 7.0 SDK][dotnet-7-sdk-download]
+
+All commands are expected to be run from the root of the repository. You'll also find that these instructions were
+derived from [these docs][aspnetcore-docker-https].
+
+### Run in Docker using https
+
+1. Configure the dev certificates.
+
+    In Powershell:
+
+    ```powershell
+    $certPassword = [System.Guid]::NewGuid()
+    dotnet dev-certs https -ep $env:USERPROFILE\.aspnet\https\aspnetapp.pfx -p $certPassword
+    dotnet dev-certs https --trust
+    ```
+
+    In Bash:
+
+    ```bash
+    dotnet dev-certs https -ep ${HOME}/.aspnet/https/aspnetapp.pfx -p <CERT_PASSWORD>
+    dotnet dev-certs https --trust
+    ```
+
+2. Build and run the container by running:
+
+    In PowerShell (assumes variables from previous PowerShell commands):
+
+    ```powershell
+    docker build -f ./src/Synology.Ddns.Update.Service/Dockerfile --force-rm -t synologyddnsupdater:local .
+    docker run -it --rm -p 58080:8080 -p 55443:5443 -e ASPNETCORE_ENVIRONMENT=Development -e ASPNETCORE_Kestrel__Certificates__Default__Password=$certPassword -e ASPNETCORE_Kestrel__Certificates__Default__Path=/https/aspnetapp.pfx -v $env:USERPROFILE/.aspnet/https:/https/ synologyddnsupdater:local
+    ```
+
+    In Bash (using CERT_PASSWORD from previous Bash commands):
+
+    ```bash
+    docker build -f ./src/Synology.Ddns.Update.Service/Dockerfile --force-rm -t synologyddnsupdater:local .
+    docker run --rm -it -p 58080:8080 -p 55443:5443 -e ASPNETCORE_ENVIRONMENT=Development -e ASPNETCORE_Kestrel__Certificates__Default__Password="<CERT_PASSWORD>" -e ASPNETCORE_Kestrel__Certificates__Default__Path=/https/aspnetapp.pfx -v ${HOME}/.aspnet/https:/https/ synologyddnsupdater:local
+    ```
+
+3. Navigate to the web page at <https://localhost:55443/swagger>.
+4. Press "Ctrl+C" to close and remove the container.
+
+### Run in Docker using http
+
+1. Build and run the container by running:
+
+    In PowerShell or Bash:
+
+    ```powershell
+    docker build -f ./src/Synology.Ddns.Update.Service/Dockerfile --force-rm -t synologyddnsupdater:local .
+    docker run --rm -it -p 58080:8080 -e ASPNETCORE_ENVIRONMENT=Development -e ASPNETCORE_URLS=http://+:8080 synologyddnsupdater:local
+    ```
+
+2. Navigate to the web page at <http://localhost:58080/swagger>.
+3. Press "Ctrl+C" to close and remove the container.
+
+The real key here is to set the `ASPNETCORE_URLS` environment variable and override the default set in the container
+that includes an https port.
+
+[aspnetcore-configuration]: https://learn.microsoft.com/aspnet/core/fundamentals/configuration/ "Configuration in ASP.NET Core"
+[aspnetcore-docker-https]: https://learn.microsoft.com/aspnet/core/security/docker-https "Hosting ASP.NET Core images with Docker over HTTPS"
+[aspnetcore-https-port]: https://learn.microsoft.com/aspnet/core/fundamentals/host/web-host#https-port "HTTPS Port"
+[aspnetcore-ratelimiting]: https://learn.microsoft.com/aspnet/core/performance/rate-limit "Rate limiting middleware in ASP.NET Core"
+[aspnetcore-server-urls]: https://learn.microsoft.com/aspnet/core/fundamentals/host/web-host#server-urls "Server URLs"
+[aspnetcore-server-urls-andrewlock]: https://andrewlock.net/5-ways-to-set-the-urls-for-an-aspnetcore-app/ "5 ways to set the URLs for an ASP.NET Core app"
+[docker]: https://www.docker.com/ "Docker"
+[docker-desktop]: https://www.docker.com/products/docker-desktop/ "Docker Desktop"
+[docker-image]: https://hub.docker.com/r/craigktreasure/synologyddnsupdater "craigktreasure/synologyddnsupdater"
+[dockerfile]: /src/Synology.Ddns.Update.Service/Dockerfile "Dockerfile"
+[dotnet-7-sdk-download]: https://dotnet.microsoft.com/en-us/download/dotnet/7.0 "Download .NET 7.0"
+[globalratelimiteroptions]: /src/Synology.Ddns.Update.Service/Options/GlobalRateLimiterOptions.cs "GlobalRateLimiterOptions.cs"
+[opentelemetry]: https://opentelemetry.io/ "OpenTelemetry"
+[create-pfx-openssl]: https://www.ssl.com/how-to/create-a-pfx-p12-certificate-file-using-openssl/ "Create a .pfx/.p12 Certificate File Using OpenSSL"

--- a/src/Synology.Ddns.Update.Service/Synology.Ddns.Update.Service.csproj
+++ b/src/Synology.Ddns.Update.Service/Synology.Ddns.Update.Service.csproj
@@ -1,9 +1,12 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <UserSecretsId>d924e848-b55c-4864-a0b5-366c2f30d047</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    <DockerDefaultDockerfile>Dockerfile</DockerDefaultDockerfile>
+    <DockerDefaultTag>synologyddnsupdater</DockerDefaultTag>
+    <DockerfileBuildArguments Condition=" '$(Configuration)' == 'Debug' ">--build-arg baseTag=7.0</DockerfileBuildArguments>
     <DockerfileContext>..\..</DockerfileContext>
 
     <NoWarn>$(NoWarn);SYSLIB1006</NoWarn>

--- a/src/Synology.Ddns.Update.Service/appsettings.Development.json
+++ b/src/Synology.Ddns.Update.Service/appsettings.Development.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "Logging": {
     "LogLevel": {
       "Default": "Information",
@@ -7,8 +7,5 @@
   },
   "MonitoringOptions": {
     "OpenTelemetryEnabled": true
-  },
-  "NamecheapDdnsClientOptions": {
-    "MockClient": true
   }
 }


### PR DESCRIPTION
- Configure and document the Docker container.
- Minor code corrections.
- The Development environment no longer uses the mock Namecheap DDNS client by default. The launchSettings.json now has profiles that have the mock client enabled.
- Fixes #4.