### PR TITLE
Deploy the web app

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -101,3 +101,32 @@ jobs:
             ${{ secrets.DOCKERHUB_USERNAME }}/synologyddnsupdater:latest
           # build on feature branches, push only on main branch
           push: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Upload webapp_package artifact for deployment job
+        uses: actions/upload-artifact@v3
+        with:
+          name: webapp_package
+          path: __publish/Release/AnyCPU/src/Synology.Ddns.Update.Service/net7.0
+
+  deploy:
+    name: 'Deploy SynologyDdnsUpdater'
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: 'production'
+      url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
+
+    steps:
+      - name: Download webapp_package artifact from build job
+        uses: actions/download-artifact@v3
+        with:
+          name: webapp_package
+          path: webapp_package
+
+      - name: Deploy to Azure Web App
+        id: deploy-to-webapp
+        uses: azure/webapps-deploy@v2
+        with:
+          app-name: ${{ vars.AZURE_WEBAPP_NAME }}
+          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
+          package: webapp_package


### PR DESCRIPTION
This change causes the CI build to deploy the web app to Azure Web Apps. See [here](https://learn.microsoft.com/azure/app-service/deploy-github-actions).