### PR TITLE
Disable `dotnet format` until bugs are fixed

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,8 +48,9 @@ jobs:
           $packageVersion = dotnet nbgv get-version --variable NuGetPackageVersion
           "container_version=$packageVersion" >> $env:GITHUB_ENV
 
-      - name: DotNet Format
-        run: dotnet format --no-restore --verify-no-changes
+      # Disable until https://github.com/dotnet/format/issues/1800 is fixed.
+      # - name: DotNet Format
+      #   run: dotnet format --no-restore --verify-no-changes
 
       - name: Build
         run: dotnet build --configuration Release --no-restore

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -24,8 +24,9 @@ jobs:
       - name: Install dependencies
         run: dotnet restore
 
-      - name: DotNet Format
-        run: dotnet format --no-restore --verify-no-changes
+      # Disable until https://github.com/dotnet/format/issues/1800 is fixed.
+      # - name: DotNet Format
+      #   run: dotnet format --no-restore --verify-no-changes
 
       - name: Build
         run: dotnet build --configuration Release --no-restore


### PR DESCRIPTION
This change disables `dotnet format` until the issues in .NET SDK 7.0.200 are fixed.