### PR TITLE
Enable GenerateDocumentationFile for tests projects

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dotnet.defaultSolution": "SynologypDdnsUpdater.sln"
+}

--- a/eng/DotNetDefaults.props
+++ b/eng/DotNetDefaults.props
@@ -31,8 +31,6 @@
 
     <!-- Generate XML documentation for not test projects. -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <GenerateDocumentationFile Condition="$(MSBuildProjectName.EndsWith('.Tests'))">false</GenerateDocumentationFile>
-    <GenerateDocumentationFile Condition="$(MSBuildProjectName.EndsWith('.ScenarioTests'))">false</GenerateDocumentationFile>
 
     <!-- Normalize file paths on CI builds. -->
     <ContinuousIntegrationBuild>$(IsCIBuild)</ContinuousIntegrationBuild>


### PR DESCRIPTION
* The .NET 7.0 SDK 7.0.400+ added new requirements for some analyzers requiring `GenerateDocumentationFile`.
* Add C# VSCode settings file.