### PR TITLE
Upgrade to .NET 8

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -200,6 +200,9 @@ csharp_style_expression_bodied_methods = when_on_single_line
 # IDE0023: Use block body for operators
 csharp_style_expression_bodied_operators = when_on_single_line
 
+# IDE0290: Use Primary Constructors
+csharp_style_prefer_primary_constructors = false
+
 # IDE0090: Use 'new(...)'
 csharp_style_implicit_object_creation_when_type_is_apparent = true
 

--- a/.github/actions/install-tools/action.yml
+++ b/.github/actions/install-tools/action.yml
@@ -6,7 +6,7 @@ runs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.x
+        dotnet-version: 8.0.100-rc.2.23502.2
 
     - name: Install .NET tools
       shell: pwsh

--- a/.github/actions/install-tools/action.yml
+++ b/.github/actions/install-tools/action.yml
@@ -6,7 +6,7 @@ runs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 8.0.100-rc.2.23502.2
+        dotnet-version: 8.x
 
     - name: Install .NET tools
       shell: pwsh

--- a/.github/workflows/Rolling.yml
+++ b/.github/workflows/Rolling.yml
@@ -22,7 +22,7 @@ jobs:
         id: update-check
         uses: ./.github/actions/image-update-check
         with:
-          base-image: mcr.microsoft.com/dotnet/aspnet:7.0-cbl-mariner2.0-distroless
+          base-image: mcr.microsoft.com/dotnet/aspnet:8.0-cbl-mariner2.0-distroless
           image: craigktreasure/synologyddnsupdater:latest
 
   build_rolling:

--- a/.github/workflows/workflow_build.yml
+++ b/.github/workflows/workflow_build.yml
@@ -61,23 +61,23 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           name: codecov
-          directory: __test-results
+          directory: __artifacts/test-results
           fail_ci_if_error: true
           verbose: true
 
-      - name: Upload output artifact
+      - name: Upload publish artifact
         if: ${{ inputs.push }}
         uses: actions/upload-artifact@v3
         with:
-          name: __publish
-          path: __publish
+          name: publish
+          path: __artifacts/publish
 
       - name: Upload webapp_package artifact for deployment job
         if: ${{ inputs.push }}
         uses: actions/upload-artifact@v3
         with:
           name: webapp_package
-          path: __publish/Release/AnyCPU/src/Synology.Ddns.Update.Service/net7.0
+          path: __artifacts/publish/Synology.Ddns.Update.Service/release
 
       - name: Set up Docker Buildx
         id: buildx
@@ -97,8 +97,8 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           file: src/Synology.Ddns.Update.Service/Dockerfile
-          # relative path to the place where source code with Dockerfile is located
-          context: __publish/Release/AnyCPU/src/Synology.Ddns.Update.Service/net7.0
+          # relative path to published binary location
+          context: __artifacts/publish/Synology.Ddns.Update.Service/release
           # build-time arguments
           build-args: |
             finalStage=fromlocal
@@ -113,8 +113,8 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           file: src/Synology.Ddns.Update.Service/Dockerfile
-          # relative path to the place where source code with Dockerfile is located
-          context: __publish/Release/AnyCPU/src/Synology.Ddns.Update.Service/net7.0
+          # relative path to published binary location
+          context: __artifacts/publish/Synology.Ddns.Update.Service/release
           # build-time arguments
           build-args: |
             finalStage=fromlocal

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,10 +4,7 @@
     <RepoRootPath>$(MSBuildThisFileDirectory)</RepoRootPath>
     <SourceRootPath>$(RepoRootPath)src</SourceRootPath>
     <UseArtifactsOutput>true</UseArtifactsOutput>
-    <ArtifactsPath>$(RepoRootPath)/__artifacts</ArtifactsPath>
-
-    <!-- Remove for final .NET 8 release. -->
-    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
+    <ArtifactsPath>$(RepoRootPath)__artifacts</ArtifactsPath>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)\eng\Defaults.props" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,12 +3,13 @@
   <PropertyGroup>
     <RepoRootPath>$(MSBuildThisFileDirectory)</RepoRootPath>
     <SourceRootPath>$(RepoRootPath)src</SourceRootPath>
-    <CentralBuildOutputPath>$(RepoRootPath)</CentralBuildOutputPath>
+    <UseArtifactsOutput>true</UseArtifactsOutput>
+    <ArtifactsPath>$(RepoRootPath)/__artifacts</ArtifactsPath>
+
+    <!-- Remove for final .NET 8 release. -->
+    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)\eng\Defaults.props" />
-
-  <!-- Import the CentralBuildOutput SDK. -->
-  <Sdk Name="Treasure.Build.CentralBuildOutput" />
 
 </Project>

--- a/eng/DotNetAnalyzers.props
+++ b/eng/DotNetAnalyzers.props
@@ -7,7 +7,7 @@
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <AnalysisLevel>7.0</AnalysisLevel>
+    <AnalysisLevel>8.0</AnalysisLevel>
   </PropertyGroup>
 
 </Project>

--- a/eng/DotNetDefaults.props
+++ b/eng/DotNetDefaults.props
@@ -10,7 +10,7 @@
     <!-- Sets the C# language version:
       https://docs.microsoft.com/dotnet/csharp/language-reference/configure-language-version#c-language-version-reference
     -->
-    <LangVersion>11.0</LangVersion>
+    <LangVersion>latest</LangVersion>
 
     <!-- Enable implicit usings:
       https://docs.microsoft.com/dotnet/core/project-sdk/overview#implicit-using-directives
@@ -46,6 +46,14 @@
   <PropertyGroup>
     <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Configure test and code coverage output. -->
+    <BaseTestResultsOutputPath>$(ArtifactsPath)/test-results/</BaseTestResultsOutputPath>
+    <BaseProjectTestResultsOutputPath>$(ArtifactsPath)/test-results/$(MSBuildProjectName)/</BaseProjectTestResultsOutputPath>
+    <VSTestResultsDirectory>$(BaseProjectTestResultsOutputPath)</VSTestResultsDirectory>
+    <CoverletOutput>$(BaseProjectTestResultsOutputPath)</CoverletOutput>
   </PropertyGroup>
 
 </Project>

--- a/eng/DotNetDefaults.props
+++ b/eng/DotNetDefaults.props
@@ -51,7 +51,7 @@
   <PropertyGroup>
     <!-- Configure test and code coverage output. -->
     <BaseTestResultsOutputPath>$(ArtifactsPath)/test-results/</BaseTestResultsOutputPath>
-    <BaseProjectTestResultsOutputPath>$(ArtifactsPath)/test-results/$(MSBuildProjectName)/</BaseProjectTestResultsOutputPath>
+    <BaseProjectTestResultsOutputPath>$(BaseTestResultsOutputPath)$(MSBuildProjectName)/</BaseProjectTestResultsOutputPath>
     <VSTestResultsDirectory>$(BaseProjectTestResultsOutputPath)</VSTestResultsDirectory>
     <CoverletOutput>$(BaseProjectTestResultsOutputPath)</CoverletOutput>
   </PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "8.0.100-rc.2.23502.2",
-    "allowPrerelease": true,
+    "version": "8.0.100",
+    "allowPrerelease": false,
     "rollForward": "latestFeature"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,10 +1,7 @@
 {
   "sdk": {
-    "version": "7.0.100",
-    "allowPrerelease": false,
+    "version": "8.0.100-rc.2.23502.2",
+    "allowPrerelease": true,
     "rollForward": "latestFeature"
-  },
-  "msbuild-sdks": {
-    "Treasure.Build.CentralBuildOutput" : "3.0.0"
   }
 }

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="7.0.13" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.6.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.6.0" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -7,7 +7,7 @@
     https://learn.microsoft.com/nuget/consume-packages/central-package-management#global-package-references
     -->
   <ItemGroup>
-    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" Condition="'$(WithoutGitRepository)' != 'true'" />
     <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" />
   </ItemGroup>
 

--- a/src/Namecheap.Library/Namecheap.Library.csproj
+++ b/src/Namecheap.Library/Namecheap.Library.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Namecheap.Library/NamecheapDdnsClient.cs
+++ b/src/Namecheap.Library/NamecheapDdnsClient.cs
@@ -13,7 +13,8 @@ using Namecheap.Library.Models;
 /// </summary>
 public class NamecheapDdnsClient : INamecheapDdnsClient, IDisposable
 {
-    private const string endpointFormat = "https://dynamicdns.park-your-domain.com/update?host={0}&domain={1}&password={2}&ip={3}";
+    private static readonly CompositeFormat EndpointFormat = CompositeFormat.Parse(
+        "https://dynamicdns.park-your-domain.com/update?host={0}&domain={1}&password={2}&ip={3}");
 
     private readonly HttpClient httpClient;
 
@@ -94,7 +95,7 @@ public class NamecheapDdnsClient : INamecheapDdnsClient, IDisposable
     {
         string endpoint = string.Format(
             CultureInfo.InvariantCulture,
-            endpointFormat,
+            EndpointFormat,
             HttpUtility.UrlEncode(host),
             HttpUtility.UrlEncode(domainName),
             HttpUtility.UrlEncode(ddnsPassword),

--- a/src/Synology.Ddns.Update.Service/BuildContainer.ps1
+++ b/src/Synology.Ddns.Update.Service/BuildContainer.ps1
@@ -22,17 +22,22 @@ param (
     [string] $TagSuffix
 )
 
-$PSNativeCommandErrorActionPreference = $true
 $ErrorActionPreference = 'Stop'
-
 
 $repoRoot = & git rev-parse --show-toplevel
 $projectFolder = $PSScriptRoot
+
+function CheckLastExitCode($message) {
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Command failed with $LASTEXITCODE. $message"
+    }
+}
 
 Push-Location $projectFolder
 try {
     Write-Host 'Restoring tools...' -ForegroundColor Magenta
     dotnet tool restore
+    CheckLastExitCode 'Restore failed.'
 }
 finally {
     Pop-Location
@@ -60,9 +65,10 @@ if ($PsCmdlet.ParameterSetName -eq 'local-build') {
         Write-Host "Performing a publish with $Configuration configuration..." -ForegroundColor Magenta
 
         dotnet publish $projectFolder --configuration $Configuration
+        CheckLastExitCode 'Publish failed.'
     }
-
-    $context = Join-Path $repoRoot "__publish/$Configuration/AnyCPU/src/Synology.Ddns.Update.Service/net7.0"
+    $configurationLower = $Configuration.ToLower()
+    $context = Join-Path $repoRoot "__artifacts/publish/Synology.Ddns.Update.Service/$configurationLower"
 
     if (-not (Test-Path $context)) {
         throw "Expected publish output was not found: $context"
@@ -71,6 +77,7 @@ if ($PsCmdlet.ParameterSetName -eq 'local-build') {
     Write-Host 'Building the container using host built application...' -ForegroundColor Magenta
 
     docker build -f $projectFolder/Dockerfile --build-arg finalStage=fromlocal --force-rm -t $tag $context
+    CheckLastExitCode 'Docker build failed.'
 }
 else {
     $context = $repoRoot
@@ -78,6 +85,7 @@ else {
     Write-Host 'Building the container using container built application...' -ForegroundColor Magenta
 
     docker build -f $projectFolder/Dockerfile --force-rm -t $tag $context
+    CheckLastExitCode 'Docker build failed.'
 }
 
 Write-Host "Built and tagged the container: $tag" -ForegroundColor Magenta

--- a/src/Synology.Ddns.Update.Service/Dockerfile
+++ b/src/Synology.Ddns.Update.Service/Dockerfile
@@ -1,6 +1,6 @@
 ﻿#See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-ARG aspNetVersion=7.0
+ARG aspNetVersion=8.0
 ARG baseTag=${aspNetVersion}-cbl-mariner2.0-distroless
 ARG buildTag=${aspNetVersion}
 ARG appPath=./
@@ -25,6 +25,7 @@ FROM mcr.microsoft.com/dotnet/sdk:${buildTag} AS build
 
 WORKDIR /repo
 
+COPY [".editorconfig", "."]
 COPY ["Directory.Build.props", "."]
 COPY ["Directory.Packages.props", "."]
 COPY ["global.json", "."]
@@ -42,19 +43,19 @@ COPY . .
 
 WORKDIR "/repo/src/Synology.Ddns.Update.Service"
 
-RUN dotnet build "Synology.Ddns.Update.Service.csproj" -c Release
+RUN dotnet build "Synology.Ddns.Update.Service.csproj" -c Release /p:WithoutGitRepository=true
 
 # Condition: finalStage=frompublish
 FROM build AS publish
 
-RUN dotnet publish "Synology.Ddns.Update.Service.csproj" -c Release /p:UseAppHost=false
+RUN dotnet publish "Synology.Ddns.Update.Service.csproj" -c Release /p:WithoutGitRepository=true /p:UseAppHost=false
 
 # Condition: finalStage=frompublish
 FROM base AS frompublish
 
 WORKDIR /app
 
-COPY --from=publish /repo/__publish/Release/AnyCPU/src/Synology.Ddns.Update.Service/net7.0 .
+COPY --from=publish /repo/__artifacts/publish/Synology.Ddns.Update.Service/release .
 
 # Condition: finalStage=fromlocal
 FROM base AS fromlocal

--- a/src/Synology.Ddns.Update.Service/MockNamecheapDdnsClient.cs
+++ b/src/Synology.Ddns.Update.Service/MockNamecheapDdnsClient.cs
@@ -23,6 +23,6 @@ internal sealed class MockNamecheapDdnsClient : INamecheapDdnsClient
             IPAddress = ipAddress,
             Language = "eng",
             ResponseCount = 0,
-            Responses = Array.Empty<NamecheapDdnsUpdateOperationResponse>()
+            Responses = []
         });
 }

--- a/src/Synology.Ddns.Update.Service/README.md
+++ b/src/Synology.Ddns.Update.Service/README.md
@@ -71,7 +71,7 @@ To build the service using the host:
 ```bash
 # From the root of the repository
 dotnet publish ./src/Synology.Ddns.Update.Service -c Release
-docker build -f ./src/Synology.Ddns.Update.Service/Dockerfile --build-arg finalStage=fromlocal --force-rm -t synologyddnsupdater:local __publish/Release/AnyCPU/src/Synology.Ddns.Update.Service/net7.0
+docker build -f ./src/Synology.Ddns.Update.Service/Dockerfile --build-arg finalStage=fromlocal --force-rm -t synologyddnsupdater:local __artifacts/publish/Synology.Ddns.Update.Service/release
 ```
 
 This method will build the service application on the host machine and then use those bits to produce the container.

--- a/src/Synology.Ddns.Update.Service/Synology.Ddns.Update.Service.csproj
+++ b/src/Synology.Ddns.Update.Service/Synology.Ddns.Update.Service.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <UserSecretsId>d924e848-b55c-4864-a0b5-366c2f30d047</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerDefaultDockerfile>Dockerfile</DockerDefaultDockerfile>

--- a/src/Synology.Namecheap.Adapter.Library/Synology.Namecheap.Adapter.Library.csproj
+++ b/src/Synology.Namecheap.Adapter.Library/Synology.Namecheap.Adapter.Library.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Synology.Namecheap.Adapter.Library/SynologyDdnsResponses.cs
+++ b/src/Synology.Namecheap.Adapter.Library/SynologyDdnsResponses.cs
@@ -1,5 +1,7 @@
 ﻿namespace Synology.Namecheap.Adapter.Library;
 
+using System.Text;
+
 internal static class SynologyDdnsResponses
 {
     public const string BadAuth = "badauth";
@@ -8,5 +10,5 @@ internal static class SynologyDdnsResponses
 
     public const string NoHost = "nohost";
 
-    public const string UnknownFormatter = "911 [{0}]";
+    public static readonly CompositeFormat UnknownFormatter = CompositeFormat.Parse("911 [{0}]");
 }

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -6,7 +6,7 @@
     <PackageVersion Include="coverlet.collector"                                Version="6.0.0" />
     <PackageVersion Include="coverlet.msbuild"                                  Version="6.0.0" />
     <PackageVersion Include="Divergic.Logging.Xunit"                            Version="4.2.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing"                  Version="7.0.13" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing"                  Version="8.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk"                            Version="17.8.0" />
     <PackageVersion Include="xunit"                                             Version="2.6.1" />
     <PackageVersion Include="xunit.runner.visualstudio"                         Version="2.5.3" />

--- a/test/Namecheap.Library.Tests/Namecheap.Library.Tests.csproj
+++ b/test/Namecheap.Library.Tests/Namecheap.Library.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Synology.Ddns.Update.Service.ScenarioTests/Synology.Ddns.Update.Service.ScenarioTests.csproj
+++ b/test/Synology.Ddns.Update.Service.ScenarioTests/Synology.Ddns.Update.Service.ScenarioTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Synology.Ddns.Update.Service.Tests/Synology.Ddns.Update.Service.Tests.csproj
+++ b/test/Synology.Ddns.Update.Service.Tests/Synology.Ddns.Update.Service.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Synology.Namecheap.Adapter.Library.Tests/NamecheapResponseAdapterTests.cs
+++ b/test/Synology.Namecheap.Adapter.Library.Tests/NamecheapResponseAdapterTests.cs
@@ -75,7 +75,7 @@ public class NamecheapResponseAdapterTests
             Command = "SETDNSHOST",
             Errors = new(),
             Language = "eng",
-            Responses = Array.Empty<NamecheapDdnsUpdateOperationResponse>(),
+            Responses = [],
             IPAddress = "127.0.0.1",
         };
 
@@ -110,6 +110,6 @@ public class NamecheapResponseAdapterTests
             },
             Language = "eng",
             ResponseCount = 1,
-            Responses = Array.Empty<NamecheapDdnsUpdateOperationResponse>(),
+            Responses = [],
         };
 }

--- a/test/Synology.Namecheap.Adapter.Library.Tests/Synology.Namecheap.Adapter.Library.Tests.csproj
+++ b/test/Synology.Namecheap.Adapter.Library.Tests/Synology.Namecheap.Adapter.Library.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Test.Library/Test.Library.csproj
+++ b/test/Test.Library/Test.Library.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.0",
+  "version": "2.0",
   "buildNumberOffset": -1,
   "nugetPackageVersion": {
     "semVer": 2


### PR DESCRIPTION
- Bumped the version to `2.0`.
- Changed `TargetFramework` to `net8.0`.
- Replaced `Treasure.Build.CentralBuildOutput` with the new `UseArtifactsOutput`. This changes the output layout and I made adjustments accordingly. The new tooling from .NET 8 doesn't configure the test output like `Treasure.Build.CentralBuildOutput` did, so I have added some configuration to redirect that output.
- Addressed new analyzer issues that come with .NET 8 and C#12.
  - Temporarily disabled CA2241 due to an analyzer issue.
  - Disabled the preference for primary constructors until I can come to grips with it.
- Fixed issues detecting command failures in `BuildContainer.ps1`.
- Fixed an issue where I wasn't including the `.editorconfig` file in the container build.
- Fixed an issue in the container build caused by the inclusion of the `Microsoft.SourceLink.GitHub` package when there isn't a repo.
- Disabled publishing test projects.