### PR TITLE
Get code coverage back to 100%

### DIFF
--- a/.github/workflows/workflow_build.yml
+++ b/.github/workflows/workflow_build.yml
@@ -61,7 +61,7 @@ jobs:
         run: dotnet build --configuration Release --no-restore
 
       - name: Test
-        run: dotnet test --configuration Release --no-build --verbosity normal --collect:"XPlat Code Coverage"
+        run: dotnet test --configuration Release --no-build --verbosity normal /p:CollectCoverage=true
 
       - name: Publish
         run: dotnet publish --configuration Release --no-build src/Synology.Ddns.Update.Service

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,0 +1,23 @@
+<Project>
+  <PropertyGroup>
+    <!-- Don't publish test projects by default. -->
+    <IsPublishable>false</IsPublishable>
+
+    <!-- Prevent test projects from being packaged by default. -->
+    <IsPackable>false</IsPackable>
+
+    <!-- Mark projects as test by default. -->
+    <IsTestProject>true</IsTestProject>
+
+    <!-- Configure code coverage settings for coverlet. -->
+    <ExcludeByAttribute>GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
+    <CoverletOutputFormat>cobertura</CoverletOutputFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Exclude test projects from code coverate reports. -->
+    <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
+  </ItemGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)/../Directory.Build.props" />
+</Project>

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -3,12 +3,13 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Packages.props, $(MSBuildThisFileDirectory)..))" />
 
   <ItemGroup>
-    <PackageVersion Include="coverlet.collector" Version="6.0.0" />
-    <PackageVersion Include="Divergic.Logging.Xunit" Version="4.2.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.12" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageVersion Include="xunit" Version="2.5.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageVersion Include="coverlet.collector"                                Version="6.0.0" />
+    <PackageVersion Include="coverlet.msbuild"                                  Version="6.0.0" />
+    <PackageVersion Include="Divergic.Logging.Xunit"                            Version="4.2.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing"                  Version="7.0.12" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk"                            Version="17.7.2" />
+    <PackageVersion Include="xunit"                                             Version="2.5.2" />
+    <PackageVersion Include="xunit.runner.visualstudio"                         Version="2.5.3" />
   </ItemGroup>
 
 </Project>

--- a/test/Namecheap.Library.Tests/Namecheap.Library.Tests.csproj
+++ b/test/Namecheap.Library.Tests/Namecheap.Library.Tests.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,8 +10,12 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />

--- a/test/Synology.Ddns.Update.Service.ScenarioTests/Synology.Ddns.Update.Service.ScenarioTests.csproj
+++ b/test/Synology.Ddns.Update.Service.ScenarioTests/Synology.Ddns.Update.Service.ScenarioTests.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,8 +14,12 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Divergic.Logging.Xunit" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />

--- a/test/Synology.Ddns.Update.Service.Tests/Synology.Ddns.Update.Service.Tests.csproj
+++ b/test/Synology.Ddns.Update.Service.Tests/Synology.Ddns.Update.Service.Tests.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,8 +10,12 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Divergic.Logging.Xunit" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/test/Synology.Namecheap.Adapter.Library.Tests/Synology.Namecheap.Adapter.Library.Tests.csproj
+++ b/test/Synology.Namecheap.Adapter.Library.Tests/Synology.Namecheap.Adapter.Library.Tests.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,8 +10,12 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />

--- a/test/Test.Library/Test.Library.csproj
+++ b/test/Test.Library/Test.Library.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+
+    <IsTestProject>false</IsTestProject>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This change tweaks the way we run Coverlet to ignore generated code when running tests.