### PR TITLE
Upgrade OpenTelemetry.Instrumentation.* to 1.6.0-beta.2

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -16,8 +16,8 @@
     <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.6.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.6.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.14" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.14" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.6.0-beta.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.6.0-beta.2" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageVersion Include="Treasure.Utils.Argument" Version="1.0.44" />
   </ItemGroup>


### PR DESCRIPTION
This change upgrades the [OpenTelemetry.Instrumentation.*](https://github.com/open-telemetry/opentelemetry-dotnet/releases) packages to `1.6.0-beta.2`. Not sure why Dependabot isn't updating them.