### PR TITLE
Add experimental support for using Azure Monitor

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.0.0-beta.8" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.6.0" />

--- a/src/Synology.Ddns.Update.Service/Extensions/OpenTelemetryExtensions.cs
+++ b/src/Synology.Ddns.Update.Service/Extensions/OpenTelemetryExtensions.cs
@@ -5,8 +5,11 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Web;
 
+using Azure.Monitor.OpenTelemetry.AspNetCore;
+
 using Microsoft.Extensions.Primitives;
 
+using OpenTelemetry;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
@@ -41,7 +44,7 @@ internal static class OpenTelemetryExtensions
                 serviceInstanceId: Environment.MachineName);
         }
 
-        builder.Services
+        OpenTelemetryBuilder openTelemetryBuilder = builder.Services
             .AddOpenTelemetry()
             .ConfigureResource(configureResource)
             .WithTracing(builder =>
@@ -66,6 +69,11 @@ internal static class OpenTelemetryExtensions
                     .AddHttpClientInstrumentation()
                     .AddAspNetCoreInstrumentation();
             });
+
+        if (monitoringOptions.AzureMonitorEnabled)
+        {
+            openTelemetryBuilder.UseAzureMonitor();
+        }
 
         // Clear default logging providers used by WebApplication host.
         builder.Logging.ClearProviders();

--- a/src/Synology.Ddns.Update.Service/Options/MonitoringOptions.cs
+++ b/src/Synology.Ddns.Update.Service/Options/MonitoringOptions.cs
@@ -8,6 +8,12 @@ internal class MonitoringOptions
     public const string SectionName = nameof(MonitoringOptions);
 
     /// <summary>
+    /// Gets or sets a value indicating whether Azure Monitor should be enabled.
+    /// Requires that <see cref="OpenTelemetryEnabled"/> is also enabled.
+    /// </summary>
+    public bool AzureMonitorEnabled { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether OpenTelemetry should be enabled.
     /// </summary>
     public bool OpenTelemetryEnabled { get; set; }

--- a/src/Synology.Ddns.Update.Service/Synology.Ddns.Update.Service.csproj
+++ b/src/Synology.Ddns.Update.Service/Synology.Ddns.Update.Service.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" />


### PR DESCRIPTION
This change adds experimental support for using [Azure Monitor](https://learn.microsoft.com/azure/azure-monitor/app/opentelemetry-enable?tabs=aspnetcore). Might use it in the future if I can verify that I can do it safely.