### PR TITLE
Upgrade OpenTelemetry packages to 1.7.0

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -15,8 +15,8 @@
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.6.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.6.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.7.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.6.0-rc.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.6.0-rc.1" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />


### PR DESCRIPTION
This change upgrades the `OpenTelemetry.Exporter.Console` and `OpenTelementry.Extensions.Hosting` packages to `1.7.0`.