### PR TITLE
Update actions/setup-dotnet to v4

### DIFF
--- a/.github/actions/install-tools/action.yml
+++ b/.github/actions/install-tools/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.x
 


### PR DESCRIPTION
This change updates the `actions/setup-dotnet` GitHub action to [v4](https://github.com/actions/setup-dotnet/releases/tag/v4.0.0).