### PR TITLE
Build container for amd64 and arm64

### DIFF
--- a/.github/workflows/workflow_build.yml
+++ b/.github/workflows/workflow_build.yml
@@ -80,6 +80,9 @@ jobs:
           name: webapp_package
           path: __artifacts/publish/Synology.Ddns.Update.Service/release
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
@@ -98,6 +101,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           file: src/Synology.Ddns.Update.Service/Dockerfile
+          platforms: linux/amd64,linux/arm64
           # relative path to published binary location
           context: __artifacts/publish/Synology.Ddns.Update.Service/release
           # build-time arguments
@@ -114,6 +118,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           file: src/Synology.Ddns.Update.Service/Dockerfile
+          platforms: linux/amd64,linux/arm64
           # relative path to published binary location
           context: __artifacts/publish/Synology.Ddns.Update.Service/release
           # build-time arguments


### PR DESCRIPTION
This change causes us to build and push containers for linux/amd64 and linux/arm64.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the build process to support multiple platforms including linux/amd64 and linux/arm64.
	- Integrated QEMU setup in the build workflow for better emulation on different architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->