### PR TITLE
Update to .NET 9.0 GA

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,9 +23,8 @@ jobs:
       # don't check format on CI builds due to common breaking changes in the .NET SDK
       checkFormat: false
 
-  # Disabled until Azure App Service supports .NET 9 RC2+
-  # deploy_ci:
-  #   name: Deploy app to Azure
-  #   needs: build_ci
-  #   uses: ./.github/workflows/workflow_deploy.yml
-  #   secrets: inherit
+  deploy_ci:
+    name: Deploy app to Azure
+    needs: build_ci
+    uses: ./.github/workflows/workflow_deploy.yml
+    secrets: inherit

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,14 +20,14 @@
 
   <ItemGroup>
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.2.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.9.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.10.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.9.0" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.0-rc.2.24473.5" /> <!-- Transitive update -->
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.0" /> <!-- Transitive update -->
     <PackageVersion Include="Treasure.Utils.Argument" Version="1.1.0" />
   </ItemGroup>
 
@@ -35,7 +35,7 @@
     <PackageVersion Include="coverlet.collector"                                Version="6.0.2" />
     <PackageVersion Include="coverlet.msbuild"                                  Version="6.0.2" />
     <PackageVersion Include="Divergic.Logging.Xunit"                            Version="4.3.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing"                  Version="8.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing"                  Version="9.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk"                            Version="17.11.1" />
     <PackageVersion Include="xunit"                                             Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio"                         Version="2.8.2" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100-rc.2.24474.11",
+    "version": "9.0.100",
     "allowPrerelease": false,
     "rollForward": "latestFeature"
   }


### PR DESCRIPTION
This change updates to .NET 9.0 GA along with a few other package updates. I've also re-enabled the deployment to Azure WebApps.