### PR TITLE
Remove Treasure.Utils.Argument

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,7 +28,6 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.0.0" />
     <PackageVersion Include="System.Text.Json" Version="9.0.0" /> <!-- Transitive update -->
-    <PackageVersion Include="Treasure.Utils.Argument" Version="1.1.0" />
   </ItemGroup>
 
   <ItemGroup Label="Test Only Packages" Condition=" '$(TestOnlyPackagesEnabled)' == 'true' ">

--- a/src/Namecheap.Library/Namecheap.Library.csproj
+++ b/src/Namecheap.Library/Namecheap.Library.csproj
@@ -4,12 +4,4 @@
     <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Using Include="Treasure.Utils" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Treasure.Utils.Argument" />
-  </ItemGroup>
-
 </Project>

--- a/src/Namecheap.Library/NamecheapDdnsClient.cs
+++ b/src/Namecheap.Library/NamecheapDdnsClient.cs
@@ -25,7 +25,11 @@ public class NamecheapDdnsClient : INamecheapDdnsClient, IDisposable
     /// </summary>
     /// <param name="httpClient">The HTTP client.</param>
     public NamecheapDdnsClient(HttpClient httpClient)
-        => this.httpClient = Argument.NotNull(httpClient);
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+
+        this.httpClient = httpClient;
+    }
 
     /// <summary>
     /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
@@ -52,10 +56,10 @@ public class NamecheapDdnsClient : INamecheapDdnsClient, IDisposable
         string ipAddress,
         CancellationToken cancellationToken = default)
     {
-        Argument.NotNullOrWhiteSpace(host);
-        Argument.NotNullOrWhiteSpace(domainName);
-        Argument.NotNullOrWhiteSpace(ddnsPassword);
-        Argument.NotNullOrWhiteSpace(ipAddress);
+        ArgumentException.ThrowIfNullOrWhiteSpace(host);
+        ArgumentException.ThrowIfNullOrWhiteSpace(domainName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(ddnsPassword);
+        ArgumentException.ThrowIfNullOrWhiteSpace(ipAddress);
 
         Uri endpoint = FormatEndpointUrl(host, domainName, ddnsPassword, ipAddress);
 

--- a/src/Synology.Ddns.Update.Service/Controllers/NamecheapDdnsController.cs
+++ b/src/Synology.Ddns.Update.Service/Controllers/NamecheapDdnsController.cs
@@ -32,11 +32,14 @@ public class NamecheapDdnsController : ControllerBase
     /// Initializes a new instance of the <see cref="NamecheapDdnsController"/> class.
     /// </summary>
     /// <param name="logger">The logger.</param>
-    /// <param name="namecheapDdnsClient">The namecheap DDNS client.</param>
+    /// <param name="namecheapDdnsClient">The Namecheap DDNS client.</param>
     public NamecheapDdnsController(ILogger<NamecheapDdnsController> logger, INamecheapDdnsClient namecheapDdnsClient)
     {
-        this.logger = Argument.NotNull(logger);
-        this.namecheapDdnsClient = Argument.NotNull(namecheapDdnsClient);
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(namecheapDdnsClient);
+
+        this.logger = logger;
+        this.namecheapDdnsClient = namecheapDdnsClient;
     }
 
     /// <summary>

--- a/src/Synology.Ddns.Update.Service/Synology.Ddns.Update.Service.csproj
+++ b/src/Synology.Ddns.Update.Service/Synology.Ddns.Update.Service.csproj
@@ -13,10 +13,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Using Include="Treasure.Utils" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" />
@@ -25,7 +21,6 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
     <PackageReference Include="Swashbuckle.AspNetCore" />
-    <PackageReference Include="Treasure.Utils.Argument" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Synology.Namecheap.Adapter.Library/NamecheapResponseAdapter.cs
+++ b/src/Synology.Namecheap.Adapter.Library/NamecheapResponseAdapter.cs
@@ -19,7 +19,7 @@ public static class NamecheapResponseAdapter
     /// <returns><see cref="string"/>.</returns>
     public static string GetSynologyResponse(NamecheapDdnsUpdateResponse namecheapResponse)
     {
-        Argument.NotNull(namecheapResponse);
+        ArgumentNullException.ThrowIfNull(namecheapResponse);
 
         if (namecheapResponse.Success)
         {

--- a/src/Synology.Namecheap.Adapter.Library/Synology.Namecheap.Adapter.Library.csproj
+++ b/src/Synology.Namecheap.Adapter.Library/Synology.Namecheap.Adapter.Library.csproj
@@ -5,10 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Using Include="Treasure.Utils" />
-  </ItemGroup>
-
-  <ItemGroup>
     <InternalsVisibleTo Include="Synology.Ddns.Update.Service.ScenarioTests" />
     <InternalsVisibleTo Include="Synology.Ddns.Update.Service.Tests" />
   </ItemGroup>


### PR DESCRIPTION
The Treasure.Utils.Argument library is unnecessary when targeting .NET 8+.