### PR TITLE
Switch to Microsoft.AspNetCore.OpenApi

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
 
   <!--
     Enable and configure Central Package Manager (CPM)
@@ -26,7 +26,7 @@
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.10.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.1.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUi" Version="7.1.0" />
     <PackageVersion Include="System.Text.Json" Version="9.0.0" /> <!-- Transitive update -->
   </ItemGroup>
 

--- a/src/Synology.Ddns.Update.Service/Controllers/NamecheapDdnsController.cs
+++ b/src/Synology.Ddns.Update.Service/Controllers/NamecheapDdnsController.cs
@@ -1,5 +1,6 @@
 ﻿namespace Synology.Ddns.Update.Service.Controllers;
 
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Metrics;
@@ -51,10 +52,15 @@ public class NamecheapDdnsController : ControllerBase
     /// <param name="ipAddress">The ip address.</param>
     /// <returns><see cref="string"/>.</returns>
     [HttpGet("update", Name = "Update")]
+    [EndpointSummary("Updates the specified host.")]
     public async Task<string> Update(
+        [Description("The host.")]
         [FromQuery(Name = "host")] string host,
+        [Description("The name of the domain.")]
         [FromQuery(Name = "domain")] string domainName,
+        [Description("The DDNS password.")]
         [FromQuery(Name = "password")] string ddnsPassword,
+        [Description("The ip address.")]
         [FromQuery(Name = "ip")] string ipAddress)
     {
         using Activity? activity = Telemetry.ActivitySource.StartActivity("NamecheapDdnsUpdate");

--- a/src/Synology.Ddns.Update.Service/Program.cs
+++ b/src/Synology.Ddns.Update.Service/Program.cs
@@ -30,17 +30,9 @@ internal sealed class Program
         // Add services to the container.
 
         builder.AddOpenTelemetry();
-
         builder.Services.AddCustomRateLimiter(builder.Configuration);
-
         builder.Services.AddControllers();
-
-        // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
-        builder.Services.AddEndpointsApiExplorer();
-        builder.Services.AddSwaggerGen(options =>
-        {
-            options.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, ThisAssembly.AssemblyName + ".xml"));
-        });
+        builder.Services.AddOpenApi();
         builder.Services.AddNamecheapDdnsClient(builder.Configuration);
 
         WebApplication app = builder.Build();
@@ -48,18 +40,17 @@ internal sealed class Program
         // Configure the HTTP request pipeline.
         if (app.Environment.IsDevelopment())
         {
-            app.UseSwagger();
-            app.UseSwaggerUI();
+            app.MapOpenApi();
+            app.UseSwaggerUI(options =>
+            {
+                options.SwaggerEndpoint("/openapi/v1.json", "Synology DDNS Update Service API");
+            });
         }
 
         app.UseHttpsRedirection();
-
         app.UseAuthorization();
-
         app.UseRateLimiter();
-
         app.MapControllers();
-
         app.Run();
     }
 }

--- a/src/Synology.Ddns.Update.Service/Synology.Ddns.Update.Service.csproj
+++ b/src/Synology.Ddns.Update.Service/Synology.Ddns.Update.Service.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
-    <PackageReference Include="Swashbuckle.AspNetCore" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUi" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This change switches OpenApi document generation to use Microsoft.AspNetCore.OpenApi. This package was already installed somehow, but wasn't being used for document generation. We still use Swashbuckle.AspNetCore.SwaggerUi for visualization. This continues to only be available in the Development environment.