### PR TITLE
Enable Dependabot to update the .NET SDK

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,13 @@ updates:
       - "Nerdbank.GitVersioning"
       - "nbgv"
 
+- package-ecosystem: 'dotnet-sdk'
+  directory: "/"
+  schedule:
+    interval: 'weekly'
+    day: 'tuesday'
+    time: '20:00'
+
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
This change enables Dependabot to update the .NET SDK per [new release](https://devblogs.microsoft.com/dotnet/using-dependabot-to-manage-dotnet-sdk-updates/).