### PR TITLE
Update xUnit to v3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,6 +21,7 @@
   <ItemGroup>
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.10.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
@@ -33,11 +34,12 @@
   <ItemGroup Label="Test Only Packages" Condition=" '$(TestOnlyPackagesEnabled)' == 'true' ">
     <PackageVersion Include="coverlet.collector"                                Version="6.0.2" />
     <PackageVersion Include="coverlet.msbuild"                                  Version="6.0.2" />
-    <PackageVersion Include="Divergic.Logging.Xunit"                            Version="4.3.1" />
+    <PackageVersion Include="Neovolve.Logging.Xunit.v3"                         Version="7.0.0-beta0006" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing"                  Version="9.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk"                            Version="17.12.0" />
-    <PackageVersion Include="xunit"                                             Version="2.9.2" />
+    <PackageVersion Include="xunit.analyzers"                                   Version="1.18.0" />
     <PackageVersion Include="xunit.runner.visualstudio"                         Version="3.0.0" />
+    <PackageVersion Include="xunit.v3"                                          Version="1.0.0" />
   </ItemGroup>
 
 </Project>

--- a/test/Namecheap.Library.Tests/Namecheap.Library.Tests.csproj
+++ b/test/Namecheap.Library.Tests/Namecheap.Library.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,11 +19,15 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="xunit.v3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Namecheap.Library.Tests/NamecheapDdnsClientTests.cs
+++ b/test/Namecheap.Library.Tests/NamecheapDdnsClientTests.cs
@@ -52,7 +52,8 @@ public class NamecheapDdnsClientTests
             host: "@",
             domainName: "mydomain.com",
             ddnsPassword: "myDdnsPassword",
-            ipAddress: "127.0.0.1");
+            ipAddress: "127.0.0.1",
+            TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(requestUri);
@@ -85,7 +86,8 @@ public class NamecheapDdnsClientTests
             host: "@",
             domainName: "mydomain.com",
             ddnsPassword: "myDdnsPassword",
-            ipAddress: "127.0.0.1");
+            ipAddress: "127.0.0.1",
+            TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(requestUri);
@@ -119,7 +121,8 @@ public class NamecheapDdnsClientTests
             host: "@&attack1=malicious",
             domainName: "mydomain.com&attack2=malicious",
             ddnsPassword: "myDdnsPassword&attack3=malicious",
-            ipAddress: "127.0.0.1&attack4=malicious");
+            ipAddress: "127.0.0.1&attack4=malicious",
+            TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(response.Success);

--- a/test/Synology.Ddns.Update.Service.ScenarioTests/Synology.Ddns.Update.Service.ScenarioTests.csproj
+++ b/test/Synology.Ddns.Update.Service.ScenarioTests/Synology.Ddns.Update.Service.ScenarioTests.csproj
@@ -1,7 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,14 +22,18 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Divergic.Logging.Xunit" />
+    <PackageReference Include="Neovolve.Logging.Xunit.v3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="xunit.v3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Synology.Ddns.Update.Service.ScenarioTests/TestWebAppFactory.cs
+++ b/test/Synology.Ddns.Update.Service.ScenarioTests/TestWebAppFactory.cs
@@ -9,8 +9,6 @@ using Microsoft.Extensions.Logging;
 
 using Test.Library;
 
-using Xunit.Abstractions;
-
 using SendAction = Func<HttpRequestMessage, HttpResponseMessage>;
 
 internal sealed class TestWebAppFactory : WebApplicationFactory<Program>

--- a/test/Synology.Ddns.Update.Service.Tests/Endpoints/NamecheapDdnsTests.cs
+++ b/test/Synology.Ddns.Update.Service.Tests/Endpoints/NamecheapDdnsTests.cs
@@ -15,14 +15,9 @@ using Synology.Namecheap.Adapter.Library;
 using Test.Library;
 using Test.Library.Namecheap;
 
-using Xunit.Abstractions;
-
-public class NamecheapDdnsTests
+[SuppressMessage("Usage", "xUnit1041:Fixture arguments to test classes must have fixture sources", Justification = "Analyzer is wrong.")]
+public class NamecheapDdnsTests(ITestOutputHelper testOutputHelper)
 {
-    private readonly ITestOutputHelper testOutputHelper;
-
-    public NamecheapDdnsTests(ITestOutputHelper testOutputHelper) => this.testOutputHelper = testOutputHelper;
-
     [Theory]
     [InlineData(SynologyDdnsResponses.NoHost, MockResponseConstants.DomainNameNotFound)]
     [InlineData("911 [Invalid IP]", MockResponseConstants.InvalidIp)]
@@ -33,7 +28,7 @@ public class NamecheapDdnsTests
     public async Task Update(string expectedResponse, string clientResponse)
     {
         // Arrange
-        ILogger<NamecheapDdns> logger = this.testOutputHelper.BuildLoggerFor<NamecheapDdns>();
+        ILogger<NamecheapDdns> logger = testOutputHelper.BuildLoggerFor<NamecheapDdns>();
         using NamecheapDdnsClient namecheapDdnsClient = BuildMockedClient(clientResponse);
         const string host = "@";
         const string domain = "mydomain.com";
@@ -51,7 +46,7 @@ public class NamecheapDdnsTests
     public async Task Update_WithClientException()
     {
         // Arrange
-        ILogger<NamecheapDdns> logger = this.testOutputHelper.BuildLoggerFor<NamecheapDdns>();
+        ILogger<NamecheapDdns> logger = testOutputHelper.BuildLoggerFor<NamecheapDdns>();
         using NamecheapDdnsClient namecheapDdnsClient = BuildMockedClient(_ => throw new InvalidOperationException());
         const string host = "@";
         const string domain = "mydomain.com";

--- a/test/Synology.Ddns.Update.Service.Tests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/test/Synology.Ddns.Update.Service.Tests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -46,7 +46,7 @@ public class ServiceCollectionExtensionsTests
         };
 
         // Act
-        RateLimitLease lease = await options.GlobalLimiter.AcquireAsync(httpContext);
+        RateLimitLease lease = await options.GlobalLimiter.AcquireAsync(httpContext, cancellationToken: TestContext.Current.CancellationToken);
 
         // Arrange
         OnRejectedContext context = new()
@@ -56,7 +56,7 @@ public class ServiceCollectionExtensionsTests
         };
 
         // Act
-        await options.OnRejected(context, default);
+        await options.OnRejected(context, TestContext.Current.CancellationToken);
     }
 
     [Fact]

--- a/test/Synology.Ddns.Update.Service.Tests/MockNamecheapDdnsClientTests.cs
+++ b/test/Synology.Ddns.Update.Service.Tests/MockNamecheapDdnsClientTests.cs
@@ -11,7 +11,8 @@ public class MockNamecheapDdnsClientTests
         MockNamecheapDdnsClient client = new();
 
         // Act
-        NamecheapDdnsUpdateResponse response = await client.UpdateHostIpAddressAsync("@", "mydomain.com", "mypassword", "127.0.0.1");
+        NamecheapDdnsUpdateResponse response = await client.UpdateHostIpAddressAsync(
+            "@", "mydomain.com", "mypassword", "127.0.0.1", TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(response.Success);

--- a/test/Synology.Ddns.Update.Service.Tests/Synology.Ddns.Update.Service.Tests.csproj
+++ b/test/Synology.Ddns.Update.Service.Tests/Synology.Ddns.Update.Service.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,13 +18,17 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Divergic.Logging.Xunit" />
+    <PackageReference Include="Neovolve.Logging.Xunit.v3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="xunit.v3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Synology.Namecheap.Adapter.Library.Tests/Synology.Namecheap.Adapter.Library.Tests.csproj
+++ b/test/Synology.Namecheap.Adapter.Library.Tests/Synology.Namecheap.Adapter.Library.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,11 +19,15 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="xunit.v3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This change updates xUnit to v3 by following the [migration guide](https://xunit.net/docs/getting-started/v3/migration).

Note: Currently using beta bits for `Neovolve.Logging.Xunit.v3`.